### PR TITLE
PAAS-480 Container HTTP Health Checks con Marathon

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -95,7 +95,7 @@ func deployFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "health-check-path",
-			Usage: "path to the health check file. ex: /v0/healthy",
+			Usage: "path to the health check file. ex: --health-check-path=/v0/healthy",
 		},
 	}
 }

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -93,6 +93,10 @@ func deployFlags() []cli.Flag {
 			Value: 0.2,
 			Usage: "Number between 0 and 1 which is multiplied with the instance count. This is the maximum number of additional instances launched at any point of time during the upgrade process, i.e. maximumOverCapacity=0.2",
 		},
+		cli.StringFlag{
+			Name:  "health-check-path",
+			Usage: "path to the health check file. ex: /v0/healthy",
+		},
 	}
 }
 
@@ -201,6 +205,7 @@ func deployCmd(c *cli.Context) {
 		Tag:       c.String("tag"),
 		MinimumHealthCapacity: c.Float64("minimumHealthCapacity"),
 		MaximumOverCapacity:   c.Float64("maximumOverCapacity"),
+		HealthCheckConfig:     &framework.HealthCheck{Path: c.String("health-check-path")},
 	}
 	applyPorts(c.StringSlice("port"), &serviceConfig)
 	if c.String("memory") != "" {

--- a/cli/deploy_test.go
+++ b/cli/deploy_test.go
@@ -277,3 +277,15 @@ func TestMaximumOverCapacityFlagOutRange(t *testing.T) {
 	err := deployBefore(ctx)
 	assert.NotNil(t, err, "Should fail")
 }
+
+func TestHealthCheckFlag(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.String("service-id", "MyServiceId", "")
+	set.String("framework", "marathon", "some hint")
+	set.String("image", "nginx", "some hint")
+	set.String("tag", "latest", "some hint")
+	set.String("health-check-path", "/v0/healhty", "usage")
+	ctx := cli.NewContext(nil, set, nil)
+	err := deployBefore(ctx)
+	assert.Nil(t, err, "Should be fine")
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	_ "github.com/latam-airlines/mesos-framework-factory/marathon"
 	"github.com/latam-airlines/crane/cli"
+	_ "github.com/latam-airlines/mesos-framework-factory/marathon"
 )
 
 func main() {


### PR DESCRIPTION
Se requiere agregar los siguientes 4 parametros al crane.yml en el framework, estos aplican de forma global para todos los despliegues.


        health-check-grace-period: 30
        health-check-interval: 20
        health-check-max-consecutive-failures: 3
        health-check-timeout: 10